### PR TITLE
Initialize project scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Python
+__pycache__/
+*.py[cod]
+*.so
+*.egg
+*.egg-info/
+*.pytest_cache/
+.env
+.venv/
+venv/
+
+# Node
+node_modules/
+dist/
+*.log
+
+# macOS
+.DS_Store
+
+# Linux
+*~
+
+# general
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# music-matcher
+# Music Matcher
+
+## Overview
+Music Matcher is a web application that matches songs to user preferences using machine learning. It consists of a FastAPI backend and a React frontend.
+
+## Tech Stack
+- **Backend:** Python 3.10+, FastAPI, SQLAlchemy, psycopg2-binary, scikit-learn, pandas, python-dotenv
+- **Frontend:** Node 18+, Vite, React, TypeScript
+
+## Local Development
+### Prerequisites
+- Python 3.10 or newer
+- Node.js 18 or newer
+- Poetry (for Python dependencies)
+
+### Setup
+1. Install Python dependencies:
+   ```bash
+   cd backend
+   poetry install
+   ```
+2. Install frontend dependencies:
+   ```bash
+   cd ../frontend
+   npm install
+   ```
+3. Start development servers:
+   ```bash
+   # In one terminal
+   cd backend
+   poetry run uvicorn main:app --reload
+
+   # In another terminal
+   cd frontend
+   npm run dev
+   ```

--- a/backend/backend/main.py
+++ b/backend/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/')
+def read_root():
+    return {'message': 'Hello from Music Matcher'}

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1,0 +1,26 @@
+# This lock file was generated in an environment without internet access
+# and serves as a placeholder. Run `poetry lock` in an online environment
+# to generate a complete lock file.
+[[package]]
+name = "fastapi"
+version = "*"
+
+[[package]]
+name = "sqlalchemy"
+version = "*"
+
+[[package]]
+name = "psycopg2-binary"
+version = "*"
+
+[[package]]
+name = "scikit-learn"
+version = "*"
+
+[[package]]
+name = "pandas"
+version = "*"
+
+[[package]]
+name = "python-dotenv"
+version = "*"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "backend"
+version = "0.1.0"
+description = "Backend service for music matcher"
+authors = ["Example <example@example.com>"]
+packages = [{ include = "backend" }]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "*"
+sqlalchemy = "*"
+psycopg2-binary = "*"
+scikit-learn = "*"
+pandas = "*"
+python-dotenv = "*"
+
+[tool.poetry.group.dev.dependencies]
+# Add dev dependencies here
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Music Matcher</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,4 @@
+#root {
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App() {
+  return <h1>Music Matcher</h1>;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import "./App.css";
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add backend and frontend directories
- configure FastAPI backend with Poetry
- scaffold frontend with Vite + React + TS
- document project setup in README
- ignore typical development artifacts

## Testing
- `poetry lock` *(fails: could not connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_687eb1df91d883259599d8b05f504638