### PR TITLE
Add FastAPI entrypoint with CORS and health check

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,24 @@
+"""Main entry point for the Music Matcher API."""
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+# Allowed origins for CORS
+ALLOWED_ORIGINS = ["http://localhost:5173"]
+
+app: FastAPI = FastAPI(title="Music Matcher API")
+
+# Configure CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/ping")
+def health_check() -> dict[str, str]:
+    """Health-check endpoint returning API status."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- create `app/main.py` under backend with a FastAPI instance
- configure CORS for `http://localhost:5173`
- add `/ping` health check route

## Testing
- `pytest -q`
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_687eb46e2ab48325a57a0ff33ec9fb94